### PR TITLE
Dbatiste/optional run delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Then navigate to  [http://localhost:8080/components/polyperf/sample/runner.html]
 
 <img width="469" alt="screen shot 2016-11-03 at 12 54 32" src="https://cloud.githubusercontent.com/assets/1369170/19982787/b20dee9e-a1c4-11e6-8d2b-d7f607eaeff9.png">
 
-The tests are run by `runner.html`, which defines the list of tests to run. Edit `runner.html` to choose test pages to run, and how many times each test should be run. By default, each test runs 25 times, but you can configure it by changing the `frame-tester`'s `runs` attribute:
+The tests are run by `runner.html`, which defines the list of tests to run. Edit `runner.html` to choose test pages to run, and how many times each test should be run. By default, each test runs 25 times with a 200ms delay between runs, but you can configure it by changing the `frame-tester`'s `runs` and/or `delay` attributes:
 
 ```
-<frame-tester runs="25"></frame-tester>
+<frame-tester runs="25" delay="300"></frame-tester>
 ```
 
-By default, the `frame-tester` reports the minimum observed run duration, however this can be configured to report the mean duration within one standard deviation:
+By default, the `frame-tester` reports the minimum observed run duration, however this can be configured with the `strategy` attribute  to report the mean duration within one standard deviation.
 
 ```
 <frame-tester strategy="onedev"></frame-tester>

--- a/perf-lib/frame-tester.html
+++ b/perf-lib/frame-tester.html
@@ -80,8 +80,7 @@
         this.base = value;
         break;
       case 'delay':
-        value = isNaN(value) ? 200 : parseInt(value);
-        this.delay = value;
+        this.delay = isNaN(value) ? 200 : parseInt(value);
         break;
       case 'strategy':
         this.strategy = this.strategies[value] || this.strategies.minimum;

--- a/perf-lib/frame-tester.html
+++ b/perf-lib/frame-tester.html
@@ -66,6 +66,7 @@
     this.log = this.querySelector('#log');
     this.attributeChangedCallback('runs', null, this.getAttribute('runs') || 25);
     this.attributeChangedCallback('base', null, this.getAttribute('base') || '');
+    this.attributeChangedCallback('delay', null, this.getAttribute('delay') || 200);
     this.attributeChangedCallback('strategy', null, this.getAttribute('strategy') || 'minimum');
     window.addEventListener('message', this.scoreMessage.bind(this));
   }
@@ -77,6 +78,10 @@
         break;
       case 'base':
         this.base = value;
+        break;
+      case 'delay':
+        value = isNaN(value) ? 200 : parseInt(value);
+        this.delay = value;
         break;
       case 'strategy':
         this.strategy = this.strategies[value] || this.strategies.minimum;
@@ -125,7 +130,13 @@
       this.shuffled = this.shuffle(this.tests);
       this.index = -1;
       //console.group('run', this.count);
-      this.nextTest();
+      if (this.delay) {
+        setTimeout(function() {
+          this.nextTest();
+        }.bind(this), this.delay);
+      } else {
+        this.nextTest();
+      }
     },
 
     nextTest: function() {


### PR DESCRIPTION
This change adds the ability to configure a delay between test runs.  This is to address the observed gradual increase in performance times doing many runs with no delay between.  A default of 200ms is set, which seems to be sufficient in tests so far.